### PR TITLE
wapo_generator excludes some valid documents

### DIFF
--- a/src/main/python/generators/wapo_generator.py
+++ b/src/main/python/generators/wapo_generator.py
@@ -43,22 +43,21 @@ class WaPoGenerator(AbstractGenerator):
                     
                     # extract body
                     document_body = ''
-                    try:
-                        if raw_document.get('contents') and len(raw_document['contents']) > 0:
-                            for item in raw_document['contents']:
-                                if item.get('subtype') == 'paragraph':
-                                    document_body += ' ' + item['content']
-                    except:
-                        continue # no content to extract
+                    if raw_document.get('contents') and len(raw_document['contents']) > 0:
+                        for item in raw_document['contents']:
+                            if item and item.get('subtype') == 'paragraph':
+                                document_body += ' ' + item['content']
                     document_body = self.__cleanhtml(document_body)
+                    document_body = document_body.replace("\n", " ").strip()
 
-                    parsed_document = {
-                        "id": doc_id,
-                        "url": str(raw_document['article_url'] or ''),
-                        "title": str(raw_document['title'] or ''), # account for empty titles
-                        "contents": document_body.replace("\n", " ").strip()
-                    }
-                    document_batch.append(parsed_document)
+                    if document_body:
+                        parsed_document = {
+                            "id": doc_id,
+                            "url": str(raw_document['article_url'] or ''),
+                            "title": str(raw_document['title'] or ''), # account for empty titles
+                            "contents": document_body
+                        }
+                        document_batch.append(parsed_document)
 
                 if len(document_batch) == self.batch_size:
                     yield document_batch


### PR DESCRIPTION
It looks like the try-catch always captures the case where there is a `None` entry in `raw_document['contents']`. These can be valid articles -- e.g.,

```
id: WAPO_9bc719f6-028d-11e2-91e7-2962c74e7738
url: https://www.washingtonpost.com/business/technology/apples-ios-6-what-you-should-know/2012/09/19/9bc719f6-028d-11e2-91e7-2962c74e7738_story.html
title: Apple’s iOS 6: What you should know
contents: Apple released its new operating system Wednesday, and iOS 6 comes with a lot of changes and added features that are important to know about. Here’s a snapshot of the most notable of more than 200 new options that Apple has adverti...
```

There are 414 such articles.