### PR TITLE
Set UTF-8 encoding explicitly when loading run files

### DIFF
--- a/run_validation/main_task/main.py
+++ b/run_validation/main_task/main.py
@@ -56,7 +56,7 @@ def load_turn_lookup_set(turns_path: str) -> dict:
 
 def load_run_file(run_file_path: str) -> CastRun:
     # validate structure
-    with open(run_file_path) as run_file:
+    with open(run_file_path, 'r', encoding='utf-8') as run_file:
         try:
             run = json.load(run_file)
             run = ParseDict(run, CastRun())


### PR DESCRIPTION
I found that the `sample_runs.json` file was sometimes failing to load correctly due to Unicode decoding errors, e.g. the sequence of bytes `0xE2 0x80 0x9C` is the valid UTF-8 character ` “` but it will fail to parse that if the file wasn't opened with UTF-8 as the encoding method. 

This is probably a system-specific thing since I think Python tries to pick a default encoding based on your OS environment and I only noticed it on a Windows system where it was defaulting to using [cp1252](https://en.wikipedia.org/wiki/Windows-1252) encoding:

```python
>>> data = json.load(open('../sample_runs/sample_run.json'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Python39\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
  File "C:\Python39\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 16485: character maps to <undefined>
>>> data = json.load(open('../sample_runs/sample_run.json', 'r', encoding='utf-8'))
```

