### PR TITLE
Restore sys.exit calls

### DIFF
--- a/run_validation/main_task/conftest.py
+++ b/run_validation/main_task/conftest.py
@@ -107,6 +107,10 @@ def grpc_stub_test(grpc_server_test):
     yield get_service_stub()
 
 @pytest.fixture
+def grpc_stub_test_invalid(grpc_server_test_invalid):
+    yield get_service_stub()
+
+@pytest.fixture
 def grpc_stub_full(grpc_server_full):
     yield get_service_stub()
 
@@ -116,6 +120,17 @@ def grpc_server_test(servicer_params_test):
     add_PassageValidatorServicer_to_server(PassageValidatorServicer(*servicer_params_test), server)
 
     server.add_insecure_port("[::]:8000")
+    server.start()
+    yield server
+
+    server.stop(None)
+
+@pytest.fixture
+def grpc_server_test_invalid(servicer_params_test):
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+    add_PassageValidatorServicer_to_server(PassageValidatorServicer(*servicer_params_test), server)
+
+    server.add_insecure_port("[::]:8999")
     server.start()
     yield server
 

--- a/run_validation/main_task/main.py
+++ b/run_validation/main_task/main.py
@@ -48,21 +48,21 @@ def load_turn_lookup_set(turns_path: str) -> dict:
     # check that topics were loaded correctly
     try:
         assert len(turn_lookup_set) == 205
-    except AssertionError as ae:
+    except AssertionError:
         logger.error('Topics file not loaded correctly')
-        raise ae
+        sys.exit(255)
 
     return turn_lookup_set
 
 def load_run_file(run_file_path: str) -> CastRun:
     # validate structure
-    with open(run_file_path) as run_file:
+    with open(run_file_path, 'r', encoding='utf-8') as run_file:
         try:
             run = json.load(run_file)
             run = ParseDict(run, CastRun())
         except Exception as e:
             logger.error(f'Run file not in the right format ({e})')
-            raise Exception(f'Run file not in the right format ({e})')
+            sys.exit(255)
 
     return run
 

--- a/run_validation/main_task/main.py
+++ b/run_validation/main_task/main.py
@@ -93,7 +93,7 @@ def validate_turn(turn: Turn, turn_lookup_set: dict, service_stub: PassageValida
 
             # check provenance
             for provenance in response.provenance:
-                previous_score, provenance_score, warning_count = check_provenance(
+                previous_score, provenance_count, warning_count = check_provenance(
                     previous_score, 
                     provenance, 
                     logger, 

--- a/run_validation/main_task/main.py
+++ b/run_validation/main_task/main.py
@@ -119,11 +119,11 @@ def validate_run(run: CastRun, turn_lookup_set: dict, service_stub: PassageValid
 
         if total_warnings > max_warnings:
             logger.error(f'Maximum number of warnings exceeded ({total_warnings} > {max_warnings}), aborting!')
-            return turns_validated, service_errors, total_warnings
+            sys.exit(255)
 
         if service_errors > 0 and strict:
             logger.error('Validation service errors encountered and strict mode enabled')
-            return turns_validated, service_errors, total_warnings
+            sys.exit(255)
 
     logger.info(f'Validation completed on {turns_validated}/{len(run.turns)} turns with {total_warnings} warnings, {service_errors} service errors')
     return turns_validated, service_errors, total_warnings

--- a/run_validation/main_task/passage_validator.py
+++ b/run_validation/main_task/passage_validator.py
@@ -10,10 +10,13 @@ class PassageValidator(PassageValidatorServicer):
     def __init__(self, db_path: str, expected_rows: int) -> None:
         self.db = PassageIDDatabase(db_path)
         if not self.db.open():
-            raise Exception('Error: failed to open database, service cannot start!')
+            print('Error: failed to open database, service cannot start!')
+            sys.exit(255)
 
         if expected_rows > 0 and self.db.rowcount != expected_rows:
-            raise Exception(f'Database row count of {self.db.rowcount} vs expected {expected_rows}, invalid path?')
+            print(f'Error: Database row count of {self.db.rowcount} vs expected {expected_rows}, invalid path?')
+            sys.exit(255)
+
         print('>> Service ready')
 
     def validate_passages(self,  passage_validation_request: PassageValidationRequest, 

--- a/run_validation/main_task/tests/test_main.py
+++ b/run_validation/main_task/tests/test_main.py
@@ -21,8 +21,11 @@ def test_load_invalid_turn_lookup_set(tmp_path):
     with open(tmp_file, 'w') as tf:
         tf.write(json_str)
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(SystemExit) as pytest_exc:
         _ = load_turn_lookup_set(tmp_file)
+
+    assert pytest_exc.type == SystemExit
+    assert pytest_exc.value.code == 255
 
 def test_load_missing_turn_lookup_set():
     with pytest.raises(Exception):
@@ -38,8 +41,11 @@ def test_validate_invalid_run_file(tmp_path):
     with open(tmp_file, 'w') as tf:
         tf.write(json_str)
 
-    with pytest.raises(Exception):
+    with pytest.raises(SystemExit) as pytest_exc:
         _ = load_run_file(tmp_file)
+
+    assert pytest_exc.type == SystemExit
+    assert pytest_exc.value.code == 255
 
 def test_validate_missing_run_file():
     with pytest.raises(OSError):

--- a/run_validation/main_task/tests/test_service.py
+++ b/run_validation/main_task/tests/test_service.py
@@ -1,0 +1,14 @@
+import pytest
+
+from passage_validator import PassageValidator
+
+def test_service_startup(servicer_params_test):
+    pv = PassageValidator(*servicer_params_test)
+    assert(pv.db.rowcount == servicer_params_test[1])
+
+def test_service_startup_invalid_rows(servicer_params_test):
+    with pytest.raises(SystemExit) as pytest_exc:
+        pv = PassageValidator(servicer_params_test[0], 12345)
+
+    assert(pytest_exc.type == SystemExit)
+    assert(pytest_exc.value.code == 255)

--- a/run_validation/main_task/utils.py
+++ b/run_validation/main_task/utils.py
@@ -22,7 +22,7 @@ def check_response(response: PassageValidationResult, logger: Logger, warning_co
 def check_provenance(previous_score: float, provenance: Provenance, logger: Logger, turn: Turn, warning_count: int, provenance_count: int) -> (float, int, int):
     if previous_score is None:
         previous_score = provenance.score
-    elif previous_score <= provenance.score:
+    elif previous_score >= provenance.score:
         previous_score = provenance.score
     elif previous_score < provenance.score:
         logger.warning(f"{provenance.id} has a greater score than previous passage. Ranking order for turn {turn.turn_id} not correct")


### PR DESCRIPTION
If it's important to keep the previous sys.exit behaviour this PR should restore that, it turned out to be pretty simple to deal with in pytest.

The bulk of the changes are updating the tests to account for the differences in behaviour this causes vs the current version. 