### PR TITLE
MI task refactoring + tests

### DIFF
--- a/run_validation/mixed_initiative_task/README.md
+++ b/run_validation/mixed_initiative_task/README.md
@@ -17,4 +17,4 @@ Run script
 - `python3 main.py CAST [path to run file]`
 
 Run tests
-- `python3 -m pytest`
+- `pytest`

--- a/run_validation/mixed_initiative_task/conftest.py
+++ b/run_validation/mixed_initiative_task/conftest.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+import pytest
+
+test_root = os.path.dirname(__file__)
+sys.path.append(os.path.join(test_root, 'compiled_protobufs'))
+
+from main import load_turn_ids, load_question_pool, load_run_file
+
+@pytest.fixture
+def turn_ids_path():
+    yield os.path.join(test_root, 'files', '2022_evaluation_topics_turn_ids.json')
+
+@pytest.fixture
+def question_pool_path():
+    yield os.path.join(test_root, 'files', '2022_mixed_initiative_question_pool.json')
+
+@pytest.fixture
+def run_file_path():
+    yield os.path.join('..', 'sample_runs', 'sample_mi_run.json')
+
+@pytest.fixture
+def turn_lookup_set(turn_ids_path):
+    yield load_turn_ids(turn_ids_path)
+
+@pytest.fixture
+def question_lookup_dict(question_pool_path):
+    yield load_question_pool(question_pool_path)
+
+@pytest.fixture
+def run_file(run_file_path):
+    yield load_run_file(run_file_path)
+
+@pytest.fixture
+def sample_run(run_file_path):
+    yield load_run_file(run_file_path)
+
+@pytest.fixture
+def sample_turn(sample_run):
+    yield sample_run.turns[0]

--- a/run_validation/mixed_initiative_task/conftest.py
+++ b/run_validation/mixed_initiative_task/conftest.py
@@ -9,6 +9,10 @@ sys.path.append(os.path.join(test_root, 'compiled_protobufs'))
 from main import load_turn_ids, load_question_pool, load_run_file
 
 @pytest.fixture
+def test_root_path():
+    yield test_root
+
+@pytest.fixture
 def turn_ids_path():
     yield os.path.join(test_root, 'files', '2022_evaluation_topics_turn_ids.json')
 

--- a/run_validation/mixed_initiative_task/main.py
+++ b/run_validation/mixed_initiative_task/main.py
@@ -69,7 +69,7 @@ def load_run_file(run_file_path: str) -> CasTMiRun:
         sys.exit(255)
 
     # validate structure
-    with open(args.path_to_run_file) as run_file:
+    with open(run_file_path) as run_file:
         try:
             run = json.load(run_file)
             run = ParseDict(run, CasTMiRun())

--- a/run_validation/mixed_initiative_task/main.py
+++ b/run_validation/mixed_initiative_task/main.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import json
 import logging
@@ -5,85 +6,141 @@ import sys
 
 from pathlib import PurePath
 
-from compiled_protobufs.mi_run_pb2 import CasTMiRun
+from compiled_protobufs.mi_run_pb2 import CasTMiRun, Turn
 from google.protobuf.json_format import ParseDict
 
-ap = argparse.ArgumentParser(description='TREC 2022 CAsT mixed initiative task validator',
-                             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-ap.add_argument('-f', '--fileroot', help='Location of data files',
-                default='.')
-ap.add_argument('task_name')
-ap.add_argument('path_to_run_file')
-args = ap.parse_args()
-
-run_file_name = PurePath(args.path_to_run_file).name
-logging.basicConfig(filename=f"{run_file_name}.errlog", level=logging.DEBUG,
-                    format='%(asctime)s %(levelname)s %(name)s %(message)s')
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
 
-warning_count = 0
+formatter = logging.Formatter('%(asctime)s %(levelname)s %(name)s %(message)s')
+streamHandler = logging.StreamHandler(sys.stdout)
+streamHandler.setFormatter(formatter)
+logger.addHandler(streamHandler)
 
-# collect all turn ids
-with open(f"{args.fileroot}/files/2022_evaluation_topics_turn_ids.json") as turn_ids_file:
-    turn_ids_dict = json.load(turn_ids_file)
+
+def load_turn_ids(turn_ids_path: str) -> set:
+    if not os.path.exists(turn_ids_path):
+        logger.error(f'Unable to open turn IDs file: {turn_ids_path}')
+        sys.exit(255)
+
     turn_lookup_set = set()
-    for topic, turn_list in turn_ids_dict.items():
-        turn_list = [f"{topic}_{turn}" for turn in turn_list]
-        for turn in turn_list:
-            turn_lookup_set.add(turn)
-# check that topics were loaded correctly
-try:
-    assert len(turn_lookup_set) == 205
-except AssertionError:
-    print("Topics file not loaded correctly")
-    sys.exit(255)
 
-# collect all questions in pool
-question_pool_dict = {}
-with open(f"{args.fileroot}/files/2022_mixed_initiative_question_pool.json") as question_pool_file:
-    question_pool = json.load(question_pool_file)
-    for question in question_pool:
-        question_pool_dict[question['question_id']] = question['question']
-# check that topics were loaded correctly
-try:
-    assert len(question_pool_dict) == 4497
-except AssertionError:
-    print("Topics file not loaded correctly")
-    sys.exit(255)
+    # collect all turn ids
+    with open(turn_ids_path) as turn_ids_file:
+        turn_ids_dict = json.load(turn_ids_file)
+        for topic, turn_list in turn_ids_dict.items():
+            turn_list = [f"{topic}_{turn}" for turn in turn_list]
+            for turn in turn_list:
+                turn_lookup_set.add(turn)
 
-# validate structure
-with open(args.path_to_run_file) as run_file:
+    # check that topics were loaded correctly
     try:
-        run = json.load(run_file)
-        run = ParseDict(run, CasTMiRun())
-    except Exception as e:
-        # Run file is not in the right format. Exit
-        logger.error(e)
-        logger.error("Run file not in the right format. Exiting...")
+        assert len(turn_lookup_set) == 205
+    except AssertionError:
+        print("Topics file not loaded correctly")
         sys.exit(255)
 
-# run checks
-if len(run.turns) == 0:
-    logger.error("Run file does not have any turns. Exiting...")
-    sys.exit(255)
+    return turn_lookup_set
 
-for turn in run.turns:
-    # check turns are valid
-    if warning_count >= 25:
-        # too many warnings
-        logger.error("Too many Warnings. Exiting..")
+def load_question_pool(question_pool_path: str) -> dict:
+    if not os.path.exists(question_pool_path):
+        logger.error(f'Unable to open question pool file: {question_pool_path}')
         sys.exit(255)
+
+    # collect all questions in pool
+    question_pool_dict = {}
+    with open(question_pool_path) as question_pool_file:
+        question_pool = json.load(question_pool_file)
+        for question in question_pool:
+            question_pool_dict[question['question_id']] = question['question']
+
+    # check that topics were loaded correctly
+    try:
+        assert len(question_pool_dict) == 4497
+    except AssertionError:
+        print("Topics file not loaded correctly")
+        sys.exit(255)
+
+    return question_pool_dict
+
+def load_run_file(run_file_path: str) -> CasTMiRun:
+    if not os.path.exists(run_file_path):
+        logger.error(f'Unable to open run file: {run_file_path}')
+        sys.exit(255)
+
+    # validate structure
+    with open(args.path_to_run_file) as run_file:
+        try:
+            run = json.load(run_file)
+            run = ParseDict(run, CasTMiRun())
+        except Exception as e:
+            # Run file is not in the right format. Exit
+            logger.error(e)
+            logger.error("Run file not in the right format. Exiting...")
+            sys.exit(255)
+
+    # run checks
+    if len(run.turns) == 0:
+        logger.error("Run file does not have any turns. Exiting...")
+        sys.exit(255)
+
+    return run
+
+def validate_turn(turn: Turn, turn_lookup_set: set, question_pool_dict: dict) -> int:
+    turn_warnings = 0
+
     if turn.turn_id in turn_lookup_set:
         for index, question in enumerate(turn.questions):
             if not question.question or not question.score:
                 logger.warning(f"Turn {turn.turn_id} contains an empty question or question without score in question ranking at index {index}")
-                warning_count += 1
+                turn_warnings += 1
             if question.question.startswith("Q") and question.question[1:].isdigit():
                 # check if question id is valid
                 if question.question not in question_pool_dict:
                     logger.warning(f"{question.question} is not valid")
-                    warning_count += 1
-
+                    turn_warnings += 1
     else:
         logger.warning(f"Turn number {turn.turn_id} is not valid")
-        warning_count += 1
+        turn_warnings += 1
+
+    return turn_warnings
+
+def validate_run(run_file_path: str, fileroot: str) -> int:
+    run_file_name = PurePath(run_file_path).name
+    fileHandler = logging.FileHandler(filename=f'{run_file_name}.errlog')
+    fileHandler.setFormatter(formatter)
+    logger.addHandler(fileHandler)
+
+    turn_lookup_set = load_turn_ids(os.path.join(fileroot, 'files/2022_evaluation_topics_turn_ids.json'))
+
+    question_pool_dict = load_question_pool(os.path.join(fileroot, 'files/2022_mixed_initiative_question_pool.json'))
+
+    run = load_run_file(run_file_path)
+
+    warning_count = 0
+
+    # check turns are valid
+    for turn in run.turns:
+        warning_count += validate_turn(turn, turn_lookup_set, question_pool_dict)
+
+        if warning_count >= 25:
+            # too many warnings
+            logger.error("Too many Warnings. Exiting..")
+            sys.exit(255)
+
+    return warning_count
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description='TREC 2022 CAsT mixed initiative task validator',
+                                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    ap.add_argument('task_name')
+    ap.add_argument('path_to_run_file')
+    ap.add_argument('-f', '--fileroot', help='Location of data files',
+                    default='.')
+    args = ap.parse_args()
+
+    if args.task_name != 'CAST':
+        logger.error(f'Unrecognised task name: {args.task_name}')
+        sys.exit(255)
+
+    validate_run(args.path_to_run_file, args.fileroot)

--- a/run_validation/mixed_initiative_task/main.py
+++ b/run_validation/mixed_initiative_task/main.py
@@ -29,7 +29,7 @@ def load_turn_ids(turn_ids_path: str) -> set:
     with open(turn_ids_path) as turn_ids_file:
         turn_ids_dict = json.load(turn_ids_file)
         for topic, turn_list in turn_ids_dict.items():
-            turn_list = [f"{topic}_{turn}" for turn in turn_list]
+            turn_list = [f'{topic}_{turn}' for turn in turn_list]
             for turn in turn_list:
                 turn_lookup_set.add(turn)
 
@@ -37,7 +37,7 @@ def load_turn_ids(turn_ids_path: str) -> set:
     try:
         assert len(turn_lookup_set) == 205
     except AssertionError:
-        print("Topics file not loaded correctly")
+        print('Topics file not loaded correctly')
         sys.exit(255)
 
     return turn_lookup_set
@@ -58,7 +58,7 @@ def load_question_pool(question_pool_path: str) -> dict:
     try:
         assert len(question_pool_dict) == 4497
     except AssertionError:
-        print("Topics file not loaded correctly")
+        print('Topics file not loaded correctly')
         sys.exit(255)
 
     return question_pool_dict
@@ -76,12 +76,12 @@ def load_run_file(run_file_path: str) -> CasTMiRun:
         except Exception as e:
             # Run file is not in the right format. Exit
             logger.error(e)
-            logger.error("Run file not in the right format. Exiting...")
+            logger.error('Run file not in the right format. Exiting...')
             sys.exit(255)
 
     # run checks
     if len(run.turns) == 0:
-        logger.error("Run file does not have any turns. Exiting...")
+        logger.error('Run file does not have any turns. Exiting...')
         sys.exit(255)
 
     return run
@@ -92,15 +92,15 @@ def validate_turn(turn: Turn, turn_lookup_set: set, question_pool_dict: dict) ->
     if turn.turn_id in turn_lookup_set:
         for index, question in enumerate(turn.questions):
             if not question.question or not question.score:
-                logger.warning(f"Turn {turn.turn_id} contains an empty question or question without score in question ranking at index {index}")
+                logger.warning(f'Turn {turn.turn_id} contains an empty question or question without score in question ranking at index {index}')
                 turn_warnings += 1
-            if question.question.startswith("Q") and question.question[1:].isdigit():
+            if question.question.startswith('Q') and question.question[1:].isdigit():
                 # check if question id is valid
                 if question.question not in question_pool_dict:
-                    logger.warning(f"{question.question} is not valid")
+                    logger.warning(f'{question.question} is not valid')
                     turn_warnings += 1
     else:
-        logger.warning(f"Turn number {turn.turn_id} is not valid")
+        logger.warning(f'Turn number {turn.turn_id} is not valid')
         turn_warnings += 1
 
     return turn_warnings
@@ -125,12 +125,12 @@ def validate_run(run_file_path: str, fileroot: str) -> int:
 
         if warning_count >= 25:
             # too many warnings
-            logger.error("Too many Warnings. Exiting..")
+            logger.error('Too many Warnings. Exiting..')
             sys.exit(255)
 
     return warning_count
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     ap = argparse.ArgumentParser(description='TREC 2022 CAsT mixed initiative task validator',
                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     ap.add_argument('task_name')

--- a/run_validation/mixed_initiative_task/main.py
+++ b/run_validation/mixed_initiative_task/main.py
@@ -1,12 +1,12 @@
-import sys
+import argparse
 import json
-import csv
-from pathlib import Path, PurePath
-from google.protobuf.json_format import Parse, ParseDict
+import logging
+import sys
+
+from pathlib import PurePath
 
 from compiled_protobufs.mi_run_pb2 import CasTMiRun
-import logging
-import argparse
+from google.protobuf.json_format import ParseDict
 
 ap = argparse.ArgumentParser(description='TREC 2022 CAsT mixed initiative task validator',
                              formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -17,9 +17,9 @@ ap.add_argument('path_to_run_file')
 args = ap.parse_args()
 
 run_file_name = PurePath(args.path_to_run_file).name
-logging.basicConfig(filename= f"{run_file_name}.errlog", level=logging.DEBUG,
+logging.basicConfig(filename=f"{run_file_name}.errlog", level=logging.DEBUG,
                     format='%(asctime)s %(levelname)s %(name)s %(message)s')
-logger=logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 warning_count = 0
 

--- a/run_validation/mixed_initiative_task/requirements.txt
+++ b/run_validation/mixed_initiative_task/requirements.txt
@@ -1,2 +1,3 @@
 grpcio 
 grpcio_tools
+pytest

--- a/run_validation/mixed_initiative_task/tests/test_main.py
+++ b/run_validation/mixed_initiative_task/tests/test_main.py
@@ -1,0 +1,112 @@
+import pytest
+
+from main import load_turn_ids, load_question_pool, load_run_file
+from main import validate_turn, validate_run
+from main import EXPECTED_POOL_SIZE, EXPECTED_TURNS
+
+def check_sys_exit(pytest_exc, code=255):
+    assert(pytest_exc.type == SystemExit)
+    assert(pytest_exc.value.code == code)
+
+def test_load_turn_ids(turn_ids_path):
+    assert(len(load_turn_ids(turn_ids_path)) == EXPECTED_TURNS)
+
+def test_load_invalid_turn_ids(tmp_path):
+    path = tmp_path / 'invalid_turn.json'
+    with open(path, 'w') as f:
+        f.write('[not valid json]{}!___')
+
+    # loading an invalid JSON file
+    with pytest.raises(SystemExit) as pytest_exc:
+        load_turn_ids(path)
+
+    check_sys_exit(pytest_exc)
+
+    path = tmp_path / 'missing_turns.json'
+    with open(path, 'w') as f:
+        f.write('{"132":[], "133":[]}')
+
+    # loading a valid JSON file with unexpected number of turns
+    with pytest.raises(SystemExit) as pytest_exc:
+        load_turn_ids(path)
+
+    check_sys_exit(pytest_exc)
+
+def test_load_missing_turn_ids(tmp_path):
+    with pytest.raises(SystemExit) as pytest_exc:
+        load_turn_ids(tmp_path / 'foobar')
+
+    check_sys_exit(pytest_exc)
+
+def test_load_question_pool(question_pool_path):
+    assert(len(load_question_pool(question_pool_path)) == EXPECTED_POOL_SIZE)
+
+def test_load_invalid_question_pool(tmp_path):
+    path = tmp_path / 'invalid_pool.json'
+    with open(path, 'w') as f:
+        f.write('[not valid json]{}!___')
+
+    with pytest.raises(SystemExit) as pytest_exc:
+        load_question_pool(path)
+
+    check_sys_exit(pytest_exc)
+
+    path = tmp_path / 'missing_pool_ids.json'
+    with open(path, 'w') as f:
+        f.write('[{}, {}]')
+
+    with pytest.raises(SystemExit) as pytest_exc:
+        load_question_pool(path)
+
+    check_sys_exit(pytest_exc)
+
+def test_load_missing_question_pool(tmp_path):
+    with pytest.raises(SystemExit) as pytest_exc:
+        load_question_pool(tmp_path / 'foobar')
+
+    check_sys_exit(pytest_exc)
+
+def test_load_run_file(run_file_path):
+    run = load_run_file(run_file_path)
+    assert(len(run.turns) == 284)
+
+def test_load_invalid_run_file(tmp_path):
+    path = tmp_path / 'invalid_run.json'
+    with open(path, 'w') as f:
+        f.write('[not valid json]{}!___')
+
+    with pytest.raises(SystemExit) as pytest_exc:
+        load_run_file(path)
+
+    check_sys_exit(pytest_exc)
+
+    path = tmp_path / 'missing_turns.json'
+    with open(path, 'w') as f:
+        f.write('[{}, {}]')
+
+    with pytest.raises(SystemExit) as pytest_exc:
+        load_run_file(path)
+
+    check_sys_exit(pytest_exc)
+
+def test_load_missing_run_file(tmp_path):
+    with pytest.raises(SystemExit) as pytest_exc:
+        load_run_file(tmp_path / 'foobar')
+
+    check_sys_exit(pytest_exc)
+
+def test_validate_turn(sample_turn, turn_lookup_set, question_lookup_dict):
+    turn_warnings = validate_turn(sample_turn, turn_lookup_set, question_lookup_dict)
+
+    assert(turn_warnings == 0)
+
+def test_validate_invalid_turn(sample_turn, turn_lookup_set, question_lookup_dict):
+    turn_warnings = validate_turn(sample_turn, set(), question_lookup_dict)
+    assert(turn_warnings == 1)
+
+    turn_warnings = validate_turn(sample_turn, turn_lookup_set, {})
+    assert(turn_warnings == 10)
+
+    del sample_turn.questions[:]
+    turn_warnings = validate_turn(sample_turn, turn_lookup_set, {})
+    assert(turn_warnings == 1)

--- a/run_validation/mixed_initiative_task/tests/test_main.py
+++ b/run_validation/mixed_initiative_task/tests/test_main.py
@@ -110,3 +110,23 @@ def test_validate_invalid_turn(sample_turn, turn_lookup_set, question_lookup_dic
     del sample_turn.questions[:]
     turn_warnings = validate_turn(sample_turn, turn_lookup_set, {})
     assert(turn_warnings == 1)
+
+def test_validate_run(run_file_path, test_root_path):
+    total_warnings = validate_run(run_file_path, test_root_path)
+    assert(total_warnings == 0)
+
+def test_validate_invalid_run(tmp_path, test_root_path):
+    with pytest.raises(SystemExit) as pytest_exc:
+        _ = validate_run(tmp_path / 'foobar', test_root_path)
+
+    check_sys_exit(pytest_exc)
+
+def test_empty_run(tmp_path, test_root_path):
+    path = tmp_path / 'empty_run.json'
+    with open(path, 'w') as f:
+        f.write('{"run_name": "empty run", "turns": []}')
+
+    with pytest.raises(SystemExit) as pytest_exc:
+        _ = validate_run(path, test_root_path)
+
+    check_sys_exit(pytest_exc)


### PR DESCRIPTION
This tries to make a very similar set of updates to `mixed_initiative_task` as with `main_task` in PR #17. 

It just splits out the code in main.py into separate methods, and then adds some tests for those new methods. 